### PR TITLE
Allow facter path to be configured.

### DIFF
--- a/collectd_facter/__init__.py
+++ b/collectd_facter/__init__.py
@@ -18,8 +18,8 @@ import subprocess
 #   processes the collectd.conf configuration stanza for this plugin
 #
 def config(c):
-  global facts, config
-
+  global facterbin, facts, config
+  facterbin = 'facter'
   facts = {}
 
   for ci in c.children:
@@ -52,6 +52,9 @@ def config(c):
 
       facts[fact] = value
 
+    elif ci.key == 'Facter':
+       facterbin = ci.values[0]
+
 
 
 # -----------------------------------------------------------------------------
@@ -64,7 +67,7 @@ def read(data=None):
   env = os.environ.copy()
   env['FACTERLIB'] = '/etc/facter'
 
-  output = subprocess.Popen((['facter', '--json']+facts.keys()), 
+  output = subprocess.Popen(([facterbin, '--json']+facts.keys()), 
 stdout=subprocess.PIPE, env=env)
   output.wait()
   output = output.stdout.read()

--- a/contrib/collect-facter.conf.example
+++ b/contrib/collect-facter.conf.example
@@ -12,6 +12,7 @@
     Fact "processorcount"
     Fact "uptime_seconds" "uptime"
     FactFile "/etc/collectd-facter.list"
+    Facter "/opt/puppetlabs/puppet/bin/facter"
   </Module>
 </Plugin>
 


### PR DESCRIPTION
facter in now often located in `/opt/puppetlabs/bin/facter`.
A new configuration

```
Facter /opt/puppetlabs/bin/facter
```

can typically be specified.