### PR TITLE
New options `MetaData` and `DefaultFloat`

### DIFF
--- a/contrib/collect-facter.conf.example
+++ b/contrib/collect-facter.conf.example
@@ -13,6 +13,8 @@
     Fact "uptime_seconds" "uptime"
     FactFile "/etc/collectd-facter.list"
     Facter "/opt/puppetlabs/puppet/bin/facter"
+    MetaData "True"
+    DefaultFloat "-1"
   </Module>
 </Plugin>
 


### PR DESCRIPTION
If MetaData is set to true then collectd
metadata will be set per metric value with
the value. e.g for `os.precessorcount`
`{value: "4"}` with be sent with the metric
value 4.0.

If `DefaultFloat` is specified then any metric
value that cannot be cast to a vote will be published
with this value. When not set any facter that cannot be
cast, e.g `x86_64` is simply not published to collectd.

These two variables can be defined to publish non
float data to collectd outputs that understand
collectd metadata. e.g write_http.